### PR TITLE
Fixed another route-collision because of a missing slash

### DIFF
--- a/lib/open_project/gitolite/engine.rb
+++ b/lib/open_project/gitolite/engine.rb
@@ -166,7 +166,7 @@ module OpenProject::Gitolite
       menu(
         :project_menu,
         :manage_git_repositories,
-        { controller: 'manage_git_repositories', action: 'index' },
+        { controller: '/manage_git_repositories', action: 'index' },
         caption: 'Manage Gitolite repository',
         param: :project_id,
         parent: :repository,


### PR DESCRIPTION
Hi again!

Followup to the search started in #7, this fixes another missing slash which caused collisions in the project menu. The calendar for example threw:

```
I, [2018-12-11T16:45:34.566955 #10898]  INFO -- : Processing by WorkPackages::CalendarsController#index as HTML
I, [2018-12-11T16:45:34.567253 #10898]  INFO -- :   Parameters: {"project_id"=>"project1"}
I, [2018-12-11T16:45:35.155588 #10898]  INFO -- :   Rendering work_packages/calendars/index.html.erb within layouts/base
I, [2018-12-11T16:45:35.541159 #10898]  INFO -- :   Rendered queries/_filters.html.erb (257.9ms)
I, [2018-12-11T16:45:36.155866 #10898]  INFO -- :   Rendered common/_calendar.html.erb (503.3ms)
I, [2018-12-11T16:45:36.157771 #10898]  INFO -- :   Rendered work_packages/_sidebar.html.erb (0.3ms)
I, [2018-12-11T16:45:36.158124 #10898]  INFO -- :   Rendered work_packages/calendars/index.html.erb within layouts/base (1002.2ms)
I, [2018-12-11T16:45:36.210515 #10898]  INFO -- :   Rendered common/_favicons.html.erb (7.0ms)
I, [2018-12-11T16:45:36.264373 #10898]  INFO -- :   Rendered work_packages/_menu_query_select.html.erb (0.1ms)
I, [2018-12-11T16:45:36.333271 #10898]  INFO -- : Completed 500 Internal Server Error in 1766ms (ActiveRecord: 153.7ms)
F, [2018-12-11T16:45:36.335125 #10898] FATAL -- :
F, [2018-12-11T16:45:36.335289 #10898] FATAL -- : ActionView::Template::Error (No route matches {:action=>"index", :controller=>"work_packages/manage_git_repositories", :layout=>nil, :project_id=>#<Project id: 3, name: "...", description: "...", is_public: false, parent_id: nil, created_on: "2018-12-04 07:15:50", updated_on: "2018-12-04 07:15:50", identifier: "project1", status: 1, lft: 1, rgt: 2>}):
F, [2018-12-11T16:45:36.335895 #10898] FATAL -- :     100:     </h2>
    101:   </div>
    102: </noscript>
    103: <% main_menu = render_main_menu(local_assigns.fetch(:menu_name, nil), @project) %>
    104: <% side_displayed = content_for?(:sidebar) || content_for?(:main_menu) || !main_menu.blank? %>
    105: <% initial_classes = initial_menu_classes(side_displayed, show_decoration) %>
    106: <div id="wrapper" style="<%= initial_menu_styles %>" class="<%= initial_classes %>">
F, [2018-12-11T16:45:36.336010 #10898] FATAL -- :
F, [2018-12-11T16:45:36.336130 #10898] FATAL -- : lib/redmine/menu_manager/menu_helper.rb:194:in `render_single_menu_node'
lib/redmine/menu_manager/menu_helper.rb:292:in `render_single_node_or_partial'
lib/redmine/menu_manager/menu_helper.rb:134:in `render_menu_node'
lib/redmine/menu_manager/menu_helper.rb:148:in `block (2 levels) in render_menu_node_with_children'
lib/redmine/menu_manager/menu_helper.rb:147:in `map'
lib/redmine/menu_manager/menu_helper.rb:147:in `block in render_menu_node_with_children'
lib/redmine/menu_manager/menu_helper.rb:145:in `render_menu_node_with_children'
lib/redmine/menu_manager/menu_helper.rb:132:in `render_menu_node'
lib/redmine/menu_manager/menu_helper.rb:64:in `block in render_menu'
lib/redmine/menu_manager/menu_helper.rb:231:in `block in menu_items_for'
lib/redmine/menu_manager/menu_helper.rb:226:in `each'
lib/redmine/menu_manager/menu_helper.rb:226:in `menu_items_for'
lib/redmine/menu_manager/menu_helper.rb:221:in `first_level_menu_items_for'
lib/redmine/menu_manager/menu_helper.rb:63:in `render_menu'
lib/redmine/menu_manager/menu_helper.rb:52:in `render_main_menu'
app/views/layouts/base.html.erb:103:in `_app_views_layouts_base_html_erb__3515985060186313045_46944079196240'
app/controllers/work_packages/calendars_controller.rb:50:in `index'
app/middleware/reset_current_user.rb:47:in `call'
```
This time against release/8.1 to spare you some work. I hope I got this right. :-)

Cheers

Jörn