### PR TITLE
Corrected wrong check which blocked install_gitolite_hooks

### DIFF
--- a/lib/open_project/gitolite/patches/settings_controller_patch.rb
+++ b/lib/open_project/gitolite/patches/settings_controller_patch.rb
@@ -13,7 +13,7 @@ module OpenProject::Gitolite
       module InstanceMethods
         def install_gitolite_hooks
           @plugin = Redmine::Plugin.find(params[:id])
-          return render_404 unless @plugin.id == :openproject_revisions_git
+          return render_404 unless @plugin.id == :openproject_gitolite
           @gitolite_checks = OpenProject::Gitolite::Config.install_hooks!
         end
       end


### PR DESCRIPTION
Hi!

There was an artifact left from the merge of openproject_revisions_git into this repo, which blocked installing the hooks on the settings-page with a http 404 error.

Jörn